### PR TITLE
Better parsing of header fields for case insensitive

### DIFF
--- a/AudioStreaming/Streaming/Parsers/HTTPHeaderParser.swift
+++ b/AudioStreaming/Streaming/Parsers/HTTPHeaderParser.swift
@@ -18,21 +18,28 @@ enum IcyHeaderField {
 }
 
 struct HTTPHeaderParserOutput {
-    let supportsSeek: Bool
     let fileLength: Int
     let typeId: AudioFileTypeID
     // Metadata Support
     let metadataStep: Int
 }
 
-struct HTTPHeaderParser: Parser {
+protocol HTTPHeaderParsing: Parser {
+    /// Returns the value for the given field of the headers in the given `HTTPURLResponse`
+    ///
+    /// - Parameters:
+    ///   - field: The header field to be search
+    ///   - response: The `HTTPURLResponse` for the header
+    /// - Returns: A `String` if the field exists in the headers otherwise `nil`
+    func value(forHTTPHeaderField field: String, in response: HTTPURLResponse) -> String?
+}
+
+struct HTTPHeaderParser: HTTPHeaderParsing {
     typealias Input = HTTPURLResponse
     typealias Output = HTTPHeaderParserOutput?
 
     func parse(input: HTTPURLResponse) -> HTTPHeaderParserOutput? {
         guard let headers = input.allHeaderFields as? [String: String], !headers.isEmpty else { return nil }
-
-        let supportsSeek = headers[HeaderField.acceptRanges] != "none"
 
         var typeId: UInt32 = 0
         if let contentType = input.mimeType {
@@ -41,13 +48,12 @@ struct HTTPHeaderParser: Parser {
 
         var fileLength: Int = 0
         if input.statusCode == 200 {
-            if let contentLength = headers[HeaderField.contentLength],
-               let length = Int(contentLength)
-            {
+            let contentLength = value(forHTTPHeaderField: HeaderField.contentLength, in: input)
+            if let contentLength = contentLength, let length = Int(contentLength) {
                 fileLength = length
             }
         } else if input.statusCode == 206 {
-            if let contentLength = headers[HeaderField.contentRange] {
+            if let contentLength = value(forHTTPHeaderField: HeaderField.contentRange, in: input) {
                 let components = contentLength.components(separatedBy: "/")
                 if components.count == 2 {
                     if let last = components.last, let length = Int(last) {
@@ -58,15 +64,38 @@ struct HTTPHeaderParser: Parser {
         }
 
         var metadataStep = 0
-        if let icyMetaint = headers[IcyHeaderField.icyMentaint],
+        if let icyMetaint = value(forHTTPHeaderField: IcyHeaderField.icyMentaint, in: input),
            let intValue = Int(icyMetaint)
         {
             metadataStep = intValue
         }
 
-        return HTTPHeaderParserOutput(supportsSeek: supportsSeek,
-                                      fileLength: fileLength,
+        return HTTPHeaderParserOutput(fileLength: fileLength,
                                       typeId: typeId,
                                       metadataStep: metadataStep)
+    }
+}
+
+extension Parser where Self: HTTPHeaderParsing {
+    func value(forHTTPHeaderField field: String, in response: HTTPURLResponse) -> String? {
+        if #available(iOS 13.0, *) {
+            return response.value(forHTTPHeaderField: field)
+        } else {
+            if let fields = response.allHeaderFields as? [String: String] {
+                return valueForCaseInsensitiveKey(field, fields: fields)
+            } else {
+                return nil
+            }
+        }
+    }
+
+    private func valueForCaseInsensitiveKey(_ key: String, fields: [String: String]) -> String? {
+        let keyToBeFound = key.lowercased()
+        for (key, value) in fields {
+            if key.lowercased() == keyToBeFound {
+                return value
+            }
+        }
+        return nil
     }
 }

--- a/AudioStreaming/Streaming/Parsers/HTTPHeaderParser.swift
+++ b/AudioStreaming/Streaming/Parsers/HTTPHeaderParser.swift
@@ -28,7 +28,7 @@ protocol HTTPHeaderParsing: Parser {
     /// Returns the value for the given field of the headers in the given `HTTPURLResponse`
     ///
     /// - Parameters:
-    ///   - field: The header field to be search
+    ///   - field: The header field to be searched
     ///   - response: The `HTTPURLResponse` for the header
     /// - Returns: A `String` if the field exists in the headers otherwise `nil`
     func value(forHTTPHeaderField field: String, in response: HTTPURLResponse) -> String?

--- a/AudioStreamingTests/Streaming/Parsers/HTTPHeaderParserTests.swift
+++ b/AudioStreamingTests/Streaming/Parsers/HTTPHeaderParserTests.swift
@@ -32,8 +32,7 @@ class HTTPHeaderParserTests: XCTestCase {
 
         // When
         let headers: [String: String] =
-            [HeaderField.acceptRanges: "range",
-             HeaderField.contentLength: "1000",
+            [HeaderField.contentLength: "1000",
              HeaderField.contentType: "audio/mp3",
              IcyHeaderField.icyMentaint: "16000"]
         let httpURLResponse = HTTPURLResponse(url: URL(string: "www.google.com")!,
@@ -46,23 +45,21 @@ class HTTPHeaderParserTests: XCTestCase {
         // Then
         XCTAssertNotNil(output)
         XCTAssertEqual(output!.fileLength, 1000)
-        XCTAssertEqual(output!.supportsSeek, true)
         XCTAssertEqual(output!.typeId, kAudioFileMP3Type)
         XCTAssertEqual(output!.metadataStep, 16000)
     }
 
-    func testReturnCorrectValuesOnRequestThatSupportsSeekRanges() throws {
+    func testReturnCorectValuesOnCaseInsensitiveHeaderFiels() throws {
         // Given
         let parser = HTTPHeaderParser()
 
         // When
         let headers: [String: String] =
-            [HeaderField.acceptRanges: "range",
-             HeaderField.contentLength: "1000",
-             HeaderField.contentType: "audio/mp3",
-             HeaderField.contentRange: "100/1000"]
+            [HeaderField.contentLength.lowercased(): "1000",
+             HeaderField.contentType.lowercased(): "audio/mp3",
+             IcyHeaderField.icyMentaint.lowercased(): "16000"]
         let httpURLResponse = HTTPURLResponse(url: URL(string: "www.google.com")!,
-                                              statusCode: 206,
+                                              statusCode: 200,
                                               httpVersion: "",
                                               headerFields: headers)
 
@@ -71,7 +68,7 @@ class HTTPHeaderParserTests: XCTestCase {
         // Then
         XCTAssertNotNil(output)
         XCTAssertEqual(output!.fileLength, 1000)
-        XCTAssertEqual(output!.supportsSeek, true)
         XCTAssertEqual(output!.typeId, kAudioFileMP3Type)
+        XCTAssertEqual(output!.metadataStep, 16000)
     }
 }


### PR DESCRIPTION
Fixes an issue where the parsing of http header fields didn't take into account case-insensitive values.