### PR TITLE
return current seeking time as progress

### DIFF
--- a/AudioStreaming/Streaming/AudioPlayer/AudioPlayer.swift
+++ b/AudioStreaming/Streaming/AudioPlayer/AudioPlayer.swift
@@ -70,7 +70,10 @@ public final class AudioPlayer {
         playerContext.entriesLock.lock()
         let playingEntry = playerContext.audioPlayingEntry
         playerContext.entriesLock.unlock()
-        guard let entry = playingEntry, !entry.seekRequest.requested else { return 0 }
+        guard let entry = playingEntry else { return 0 }
+        if entry.seekRequest.requested {
+            return entry.seekRequest.time
+        }
         return entry.progress
     }
 

--- a/AudioStreaming/Streaming/AudioPlayer/AudioPlayer.swift
+++ b/AudioStreaming/Streaming/AudioPlayer/AudioPlayer.swift
@@ -71,8 +71,12 @@ public final class AudioPlayer {
         let playingEntry = playerContext.audioPlayingEntry
         playerContext.entriesLock.unlock()
         guard let entry = playingEntry else { return 0 }
-        if entry.seekRequest.requested {
-            return entry.seekRequest.time
+        entry.seekRequest.lock.lock()
+        let seekRequested = entry.seekRequest.requested
+        let seekTime = entry.seekRequest.time
+        entry.seekRequest.lock.unlock()
+        if seekRequested {
+            return seekTime
         }
         return entry.progress
     }


### PR DESCRIPTION
It's better to return current progress when user is seeking.

For example, if we want to implement a fast forward button(30s), and the user clicks on the fast forward button, the logic is
> seek(player.progress + 30 seconds)

when the user clicks fast forward twice quickly, the second click will player.progress will be 0, which is incorrect. 
so this pr fixes the case.

Please consider :)