### PR TITLE
Fix header not get passed into method

### DIFF
--- a/AudioStreaming/Streaming/Audio Entry/AudioEntryProvider.swift
+++ b/AudioStreaming/Streaming/Audio Entry/AudioEntryProvider.swift
@@ -46,10 +46,10 @@ final class AudioEntryProvider: AudioEntryProviding {
         FileAudioSource(url: url, underlyingQueue: underlyingQueue)
     }
 
-    func source(for url: URL, headers _: [String: String]) -> CoreAudioStreamSource {
+    func source(for url: URL, headers: [String: String]) -> CoreAudioStreamSource {
         guard !url.isFileURL else {
             return provideFileAudioSource(url: url)
         }
-        return provideAudioSource(url: url, headers: [:])
+        return provideAudioSource(url: url, headers: headers)
     }
 }


### PR DESCRIPTION
`player.play(url: url,headers: ["Authorization": "Bearer eyJhbGciOiJI...."])`

When passing header as above is getting replaced by empty headers
