### PR TITLE
Fixes a memory leak issue in RemoteAudioSource

### DIFF
--- a/AudioStreaming/Streaming/Audio Source/RemoteAudioSource.swift
+++ b/AudioStreaming/Streaming/Audio Source/RemoteAudioSource.swift
@@ -110,7 +110,6 @@ public class RemoteAudioSource: AudioStreamSource {
     func close() {
         retrierTimeout.cancel()
         netStatusService.stop()
-        streamOperationQueue.isSuspended = true
         streamOperationQueue.cancelAllOperations()
         if let streamTask = streamRequest {
             streamTask.cancel()


### PR DESCRIPTION
Cancelling operations on a suspended OperationQueue does not releases the operations causing memory leak