### PR TITLE
Fixes an issue where the memory is not released after paused audio

### DIFF
--- a/AudioStreaming/Streaming/Audio Source/RemoteAudioSource.swift
+++ b/AudioStreaming/Streaming/Audio Source/RemoteAudioSource.swift
@@ -110,6 +110,7 @@ public class RemoteAudioSource: AudioStreamSource {
     func close() {
         retrierTimeout.cancel()
         netStatusService.stop()
+        streamOperationQueue.isSuspended = false
         streamOperationQueue.cancelAllOperations()
         if let streamTask = streamRequest {
             streamTask.cancel()
@@ -137,12 +138,10 @@ public class RemoteAudioSource: AudioStreamSource {
     }
 
     func suspend() {
-        streamRequest?.suspend()
         streamOperationQueue.isSuspended = true
     }
 
     func resume() {
-        streamRequest?.resume()
         streamOperationQueue.isSuspended = false
     }
 


### PR DESCRIPTION
Resolves an issue reported by a re-opened issue #28

When starting a new audio player memory wasn't released when a previous audio was in paused state.