### PR TITLE
Audio interruption and audio route change handling

### DIFF
--- a/AudioStreaming/Streaming/AudioPlayer/AudioPlayerDelegate.swift
+++ b/AudioStreaming/Streaming/AudioPlayer/AudioPlayerDelegate.swift
@@ -31,4 +31,32 @@ public protocol AudioPlayerDelegate: AnyObject {
 
     /// Tells the delegate when a metadata read occurred from the stream.
     func audioPlayerDidReadMetadata(player: AudioPlayer, metadata: [String: String])
+    
+    /// Tells the delegate that the audio was interrupted by system
+    func audioPlayerWasInterrupted(player: AudioPlayer)
+    
+    /// Tells the delegate that the audio interruption did end
+    func audioPlayerInterruptionDidEnd(player: AudioPlayer)
+    
+    /// Tells the delegate that the audio was paused due to route change
+    /// automaticallyPauseOnNoisyRouteChange must be true for this to occur
+    func audioPlayerDidPauseOnNoisyRouteChange(player: AudioPlayer)
+    
+}
+
+/// Optionals
+public extension AudioPlayerDelegate {
+    
+    func audioPlayerWasInterrupted(player: AudioPlayer) {
+        
+    }
+    
+    func audioPlayerInterruptionDidEnd(player: AudioPlayer) {
+        
+    }
+    
+    func audioPlayerDidPauseOnNoisyRouteChange(player: AudioPlayer) {
+        
+    }
+    
 }


### PR DESCRIPTION
The player is gracefully paused on interruption and pauses audio playback on noisy route change, according to good behaviour expectations. Delegate callbacks let the client know when this occurs

Apple resources
https://developer.apple.com/documentation/avfaudio/avaudiosession/responding_to_audio_session_interruptions https://developer.apple.com/documentation/avfaudio/avaudiosession/responding_to_audio_session_route_changes