### PR TITLE
Lazy initialize singleton mixer node

### DIFF
--- a/AudioStreaming/Streaming/AudioPlayer/AudioPlayer.swift
+++ b/AudioStreaming/Streaming/AudioPlayer/AudioPlayer.swift
@@ -108,7 +108,7 @@ open class AudioPlayer {
     private var stateBeforePaused: InternalState = .initial
 
     /// The underlying `AVAudioEngine` object
-    private let audioEngine = AVAudioEngine()
+    private let audioEngine: AVAudioEngine
     /// An `AVAudioUnit` object that represents the audio player
     private(set) var player = AVAudioUnit()
     /// An `AVAudioUnitTimePitch` that controls the playback rate of the audio engine
@@ -134,7 +134,8 @@ open class AudioPlayer {
 
     public init(configuration: AudioPlayerConfiguration = .default) {
         self.configuration = configuration.normalizeValues()
-
+        let engine = AVAudioEngine()
+        self.audioEngine = engine
         rendererContext = AudioRendererContext(configuration: configuration, outputAudioFormat: outputAudioFormat)
         playerContext = AudioPlayerContext()
         entriesQueue = PlayerQueueEntries()
@@ -150,12 +151,14 @@ open class AudioPlayer {
                                                        rendererContext: rendererContext,
                                                        outputAudioFormat: outputAudioFormat.basicStreamDescription)
 
-        frameFilterProcessor = FrameFilterProcessor(mixerNode: audioEngine.mainMixerNode)
-
         playerRenderProcessor = AudioPlayerRenderProcessor(playerContext: playerContext,
                                                            rendererContext: rendererContext,
                                                            outputAudioFormat: outputAudioFormat.basicStreamDescription)
 
+        
+        frameFilterProcessor = FrameFilterProcessor(mixerNodeProvider: {
+            engine.mainMixerNode
+        })
         configPlayerContext()
         configPlayerNode()
         setupEngine()

--- a/AudioStreaming/Streaming/AudioPlayer/Processors/FrameFilterProcessor.swift
+++ b/AudioStreaming/Streaming/AudioPlayer/Processors/FrameFilterProcessor.swift
@@ -78,14 +78,17 @@ final class FrameFilterProcessor: NSObject, FrameFiltering {
     }
 
     private let lock = UnfairLock()
-    private let mixerNode: AVAudioMixerNode
+    private let mixerNodeProvider: (() -> AVAudioMixerNode)
+    private lazy var mixerNode: AVAudioMixerNode = {
+        return mixerNodeProvider()
+    }()
 
     private(set) var entries: [FilterEntry] = []
 
     private var hasInstalledTap: Bool = false
 
-    init(mixerNode: AVAudioMixerNode) {
-        self.mixerNode = mixerNode
+    init(mixerNodeProvider: @escaping (() -> AVAudioMixerNode)) {
+        self.mixerNodeProvider = mixerNodeProvider
     }
 
     public func add(entry: FilterEntry) {


### PR DESCRIPTION
This is a fix for issue [49](https://github.com/dimitris-c/AudioStreaming/issues/49). According to apple, the `mainMixerNode` singleton has an side effect on first access. This is why `AudioPlayer` initializer will stop existing background audio. The fix defer the access by making it inside a lazy var.

```
The audio engine constructs a singleton main mixer and connects it to the [outputNode](https://developer.apple.com/documentation/avfaudio/avaudioengine/1389103-outputnode) when first accessing this property. You can then connect additional audio nodes to the mixer
```
