### PR TITLE
fix(StopReason): Fix incorrect stopReason on finish delegate method

### DIFF
--- a/AudioStreaming/Streaming/AudioPlayer/AudioPlayerContext.swift
+++ b/AudioStreaming/Streaming/AudioPlayer/AudioPlayerContext.swift
@@ -42,7 +42,9 @@ internal final class AudioPlayerContext {
                                    when inState: ((AudioPlayer.InternalState) -> Bool)? = nil)
     {
         let newValues = playerStateAndStopReason(for: state)
-        stopReason.write { $0 = newValues.stopReason }
+        if let stopReason = newValues.stopReason {
+            self.stopReason.write { $0 = stopReason }
+        }
         guard state != internalState else { return }
         if let inState = inState, !inState(internalState) {
             return

--- a/AudioStreaming/Streaming/AudioPlayer/AudioPlayerState.swift
+++ b/AudioStreaming/Streaming/AudioPlayer/AudioPlayerState.swift
@@ -30,26 +30,27 @@ extension AudioPlayer {
 /// Helper method that returns `AudioPlayerState` and `StopReason` based on the given `InternalState`
 /// - Parameter internalState: A value of `InternalState`
 /// - Returns: A tuple of `(AudioPlayerState, AudioPlayerStopReason)`
-func playerStateAndStopReason(for internalState: AudioPlayer.InternalState) -> (state: AudioPlayerState,
-                                                                                stopReason: AudioPlayerStopReason)
+func playerStateAndStopReason(
+    for internalState: AudioPlayer.InternalState
+) -> (state: AudioPlayerState, stopReason: AudioPlayerStopReason?)
 {
     switch internalState {
     case .initial:
-        return (.ready, .none)
+        return (.ready, AudioPlayerStopReason.none)
     case .running, .playing, .waitingForDataAfterSeek:
-        return (.playing, .none)
+        return (.playing, AudioPlayerStopReason.none)
     case .pendingNext, .rebuffering, .waitingForData:
-        return (.bufferring, .none)
+        return (.bufferring, AudioPlayerStopReason.none)
     case .stopped:
-        return (.stopped, .userAction)
+        return (.stopped, nil)
     case .paused:
-        return (.paused, .none)
+        return (.paused, AudioPlayerStopReason.none)
     case .disposed:
         return (.disposed, .userAction)
     case .error:
-        return (.error, .error)
+        return (.error, AudioPlayerStopReason.error)
     default:
-        return (.ready, .none)
+        return (.ready, AudioPlayerStopReason.none)
     }
 }
 


### PR DESCRIPTION
This fixes #53 

`audioPlayerDidFinishPlaying` did not report the correct stopReason when a source ended. The stropReason should now be `.eof` instead of `.none`

Please note that if items are queued only the `audioPlayerDidFinishPlaying` will only report a `stopReason` of `.eof` when the last item on the queue finishes.