### PR TITLE
Mark state and error types as Sendable

### DIFF
--- a/AudioStreaming/Core/Extensions/AudioConverter+Helpers.swift
+++ b/AudioStreaming/Core/Extensions/AudioConverter+Helpers.swift
@@ -5,7 +5,7 @@
 
 import AVFoundation
 
-public enum AudioConverterError: CustomDebugStringConvertible {
+public enum AudioConverterError: CustomDebugStringConvertible, Sendable {
     case badPropertySizeError
     case formatNotSupported
     case inputSampleRateOutOfRange

--- a/AudioStreaming/Core/Extensions/AudioFileStream+Helpers.swift
+++ b/AudioStreaming/Core/Extensions/AudioFileStream+Helpers.swift
@@ -29,7 +29,7 @@ func fileStreamGetPropertyInfo(fileStream streamId: AudioFileStreamID, propertyI
 ///
 /// Reference:
 /// [Audio File Stream Errors](https://developer.apple.com/documentation/audiotoolbox/1391572-audio_file_stream_errors?language=objc)
-public enum AudioFileStreamError: CustomDebugStringConvertible {
+public enum AudioFileStreamError: CustomDebugStringConvertible, Sendable {
     case badPropertySize
     case dataUnavailable
     case discontinuityCantRecover

--- a/AudioStreaming/Streaming/AudioPlayer/AudioPlayerState.swift
+++ b/AudioStreaming/Streaming/AudioPlayer/AudioPlayerState.swift
@@ -55,7 +55,7 @@ func playerStateAndStopReason(
 
 // MARK: Public States
 
-public enum AudioPlayerState: Equatable {
+public enum AudioPlayerState: Equatable, Sendable {
     case ready
     case running
     case playing
@@ -66,7 +66,7 @@ public enum AudioPlayerState: Equatable {
     case disposed
 }
 
-public enum AudioPlayerStopReason: Equatable {
+public enum AudioPlayerStopReason: Equatable, Sendable {
     case none
     case eof
     case userAction
@@ -74,7 +74,7 @@ public enum AudioPlayerStopReason: Equatable {
     case disposed
 }
 
-public enum AudioPlayerError: LocalizedError, Equatable {
+public enum AudioPlayerError: LocalizedError, Equatable, Sendable {
     case streamParseBytesFailure(AudioFileStreamError)
     case audioSystemError(AudioSystemError)
     case codecError
@@ -100,7 +100,7 @@ public enum AudioPlayerError: LocalizedError, Equatable {
     }
 }
 
-public enum AudioSystemError: LocalizedError, Equatable {
+public enum AudioSystemError: LocalizedError, Equatable, Sendable {
     case engineFailure
     case playerNotFound
     case playerStartError


### PR DESCRIPTION
This is a minor change to help client apps that are using Swift strict concurrency. Marking certain types `Sendable` allows clients to pass these values from one actor to another. The updated types are:

- `AudioPlayerState`
- `AudioPlayerStopReason`
- `AudioConverterError`
- `AudioFileStreamError`
- `AudioPlayerError`
- `AudioSystemError`