### PR TITLE
Support customizing HTTP method and HTTP body

### DIFF
--- a/AudioStreaming/Streaming/Audio Source/RemoteAudioSource.swift
+++ b/AudioStreaming/Streaming/Audio Source/RemoteAudioSource.swift
@@ -25,6 +25,8 @@ public class RemoteAudioSource: AudioStreamSource {
     }
 
     private let url: URL
+    private let httpMethod: String?
+    private let httpBody: Data?
     private let networkingClient: NetworkingClient
     private var streamRequest: NetworkDataStream?
 
@@ -61,12 +63,16 @@ public class RemoteAudioSource: AudioStreamSource {
          netStatusProvider: NetStatusProvider,
          retrier: Retrier,
          url: URL,
+         httpMethod: String?,
+         httpBody: Data?,
          underlyingQueue: DispatchQueue,
          httpHeaders: [String: String])
     {
         networkingClient = networking
         metadataStreamProcessor = metadataStreamSource
         self.url = url
+        self.httpMethod = httpMethod
+        self.httpBody = httpBody
         additionalRequestHeaders = httpHeaders
         relativePosition = 0
         seekOffset = 0
@@ -83,9 +89,11 @@ public class RemoteAudioSource: AudioStreamSource {
         mp4Restructure = RemoteMp4Restructure(url: url, networking: networkingClient)
         startNetworkService()
     }
-
+    
     convenience init(networking: NetworkingClient,
                      url: URL,
+                     httpMethod: String?,
+                     httpBody: Data?,
                      underlyingQueue: DispatchQueue,
                      httpHeaders: [String: String])
     {
@@ -100,6 +108,21 @@ public class RemoteAudioSource: AudioStreamSource {
                   netStatusProvider: netStatusProvider,
                   retrier: retrierTimeout,
                   url: url,
+                  httpMethod: httpMethod,
+                  httpBody: httpBody,
+                  underlyingQueue: underlyingQueue,
+                  httpHeaders: httpHeaders)
+    }
+
+    convenience init(networking: NetworkingClient,
+                     url: URL,
+                     underlyingQueue: DispatchQueue,
+                     httpHeaders: [String: String])
+    {
+        self.init(networking: networking,
+                  url: url,
+                  httpMethod: nil,
+                  httpBody: nil,
                   underlyingQueue: underlyingQueue,
                   httpHeaders: httpHeaders)
     }
@@ -347,6 +370,8 @@ public class RemoteAudioSource: AudioStreamSource {
         urlRequest.networkServiceType = .avStreaming
         urlRequest.cachePolicy = .reloadIgnoringLocalCacheData
         urlRequest.timeoutInterval = 60
+        urlRequest.httpMethod = httpMethod
+        urlRequest.httpBody = httpBody
 
         for header in additionalRequestHeaders {
             urlRequest.addValue(header.value, forHTTPHeaderField: header.key)
@@ -366,6 +391,8 @@ public class RemoteAudioSource: AudioStreamSource {
         urlRequest.networkServiceType = .avStreaming
         urlRequest.cachePolicy = .reloadIgnoringLocalCacheData
         urlRequest.timeoutInterval = 60
+        urlRequest.httpMethod = httpMethod
+        urlRequest.httpBody = httpBody
 
         for header in additionalRequestHeaders {
             urlRequest.addValue(header.value, forHTTPHeaderField: header.key)

--- a/AudioStreaming/Streaming/AudioPlayer/AudioPlayer.swift
+++ b/AudioStreaming/Streaming/AudioPlayer/AudioPlayer.swift
@@ -192,6 +192,17 @@ open class AudioPlayer {
         let audioEntry = entryProvider.provideAudioEntry(url: url, headers: headers)
         play(audioEntry: audioEntry)
     }
+    
+    /// Starts the audio playback for the given URL
+    ///
+    /// - parameter url: A `URL` specifying the audio context to be played.
+    /// - parameter httpMethod: A `String` specifying the HTTP method to use (e.g. "GET", "POST").
+    /// - parameter httpBody: A "Data" specifying the HTTP request body, if any.
+    /// - parameter headers: A `Dictionary` specifying any additional headers to be pass to the network request.
+    public func play(url: URL, httpMethod: String?, httpBody: Data?, headers: [String: String]) {
+        let audioEntry = entryProvider.provideAudioEntry(url: url, httpMethod: httpMethod, httpBody: httpBody, headers: headers)
+        play(audioEntry: audioEntry)
+    }
 
     /// Starts the audio playback for the supplied stream
     ///


### PR DESCRIPTION
This PR introduces the ability to specify a custom HTTP method (e.g., `POST`) and an HTTP body when fetching remote audio streams. Previously, all remote audio requests were hardcoded to use the `GET` method with no body.

**Motivation & Context:**

The primary motivation for this enhancement is to support services like ElevenLabs, which often require `POST` requests with a JSON body (e.g., to send text for speech synthesis).

While ElevenLabs is a specific use case driving this change, the implementation focuses on general extensibility. By allowing customization of the HTTP method and body, we make the `AudioStreaming` module more versatile and capable of integrating with a wider range of audio streaming APIs that may have requirements beyond simple `GET` requests.

**Key Changes:**

* **`AudioEntryProvider.swift`**:
    * Extended the `AudioEntryProviding` protocol and `AudioEntryProvider` class to accept `httpMethod: String?` and `httpBody: Data?` parameters when creating an `AudioEntry`.
    * Updated internal methods (`provideAudioSource`, `source`) to propagate these new parameters.
    * Existing methods for providing audio entries without these parameters default to `GET` with no body, ensuring backward compatibility.

* **`RemoteAudioSource.swift`**:
    * Added `httpMethod` and `httpBody` properties.
    * Modified initializers to accept and store these new parameters.
    * Updated `URLRequest` creation within `startStreamingAudioDataRequest` and `startGetContentLengthRequest` to set the `httpMethod` and `httpBody` if provided.

* **`AudioPlayer.swift`**:
    * Added a new public `play` method:
        ```swift
        public func play(url: URL, httpMethod: String?, httpBody: Data?, headers: [String: String])
        ```
        This allows clients to directly leverage the new customization options.

These changes provide a more flexible way to interact with remote audio sources. Existing methods remain in place for backward compatibility.