### PR TITLE
Expose the framesPlayed attribute so progress can be tracked based on frames instead of time

### DIFF
--- a/AudioStreaming/Streaming/Audio Entry/AudioEntry.swift
+++ b/AudioStreaming/Streaming/Audio Entry/AudioEntry.swift
@@ -37,6 +37,11 @@ class AudioEntry {
         return seekTime + (Double(framesState.played) / outputAudioFormat.sampleRate)
     }
 
+    var framesPlayed: Int {
+        lock.lock(); defer { lock.unlock() }
+        return framesState.played
+    }
+
     var audioStreamFormat = AudioStreamBasicDescription()
 
     /// Hold the seek time, if a seek was requested

--- a/AudioStreaming/Streaming/AudioPlayer/AudioPlayer.swift
+++ b/AudioStreaming/Streaming/AudioPlayer/AudioPlayer.swift
@@ -81,6 +81,16 @@ open class AudioPlayer {
         return entry.progress
     }
 
+    /// The number of audio frames that have been played
+    public var framesPlayed: Int {
+        guard playerContext.internalState != .pendingNext else { return 0 }
+        playerContext.entriesLock.lock()
+        let playingEntry = playerContext.audioPlayingEntry
+        playerContext.entriesLock.unlock()
+        guard let entry = playingEntry else { return 0 }
+        return entry.framesPlayed
+    }
+
     public private(set) var customAttachedNodes = [AVAudioNode]()
 
     /// The current configuration of the player.


### PR DESCRIPTION
I think its a bit easier to do operations on frames instead of time if possible. 