### PR TITLE
fix seek crash: Double value gets infinit and can't be converted to Int64

### DIFF
--- a/AudioStreaming/Streaming/AudioPlayer/Processors/AudioFileStreamProcessor.swift
+++ b/AudioStreaming/Streaming/AudioPlayer/Processors/AudioFileStreamProcessor.swift
@@ -104,6 +104,8 @@ final class AudioFileStreamProcessor {
         let dataLengthInBytes = Double(readingEntry.audioDataLengthBytes())
         let entryDuration = readingEntry.duration()
         let duration = entryDuration < readingEntry.progress && entryDuration > 0 ? readingEntry.progress : entryDuration
+      
+        guard duration > 0.0 else { return }
 
         var seekByteOffset = Int64(dataOffset + (readingEntry.seekRequest.time / duration) * dataLengthInBytes)
 


### PR DESCRIPTION
When a server is in the process of transcoding it can happen that the reported duration is 0. The calculation of seekByteOffset expects a value which is valid for Int64. Without the added check the expression in Int64() is not valid (division by 0) and the system crashes. With this check the seek request is ignored.